### PR TITLE
Updated dependencies and fixed compilation on Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <extension.name>javax.interceptor</extension.name>
         <spec.version>1.2</spec.version>
         <non.final>false</non.final>
-        <findbugs.version>2.3.1</findbugs.version>
+        <findbugs.version>3.0.1</findbugs.version>
         <findbugs.exclude>exclude.xml</findbugs.exclude>
         <findbugs.threshold>Low</findbugs.threshold>
     </properties>
@@ -101,7 +101,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.3</version>
                 <configuration>
                     <spec>
                         <nonFinal>${non.final}</nonFinal>
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.3</version>
+                <version>4.0.0</version>
                 <configuration>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
@@ -165,7 +165,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-remote-resources-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.5</version>
                 <executions>
                   <execution>
                     <goals>
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.0.1</version>
                 <configuration>
                     <includePom>true</includePom>
                 </configuration>
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
                 <configuration>
                     <bottom>
 <![CDATA[Copyright &#169; 1996-2013,
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.7.1</version>
                 <configuration>
                     <reporting>
                         <plugins>
@@ -279,6 +279,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -295,7 +296,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <additionalparam>${javadoc.options}</additionalparam>
                     </configuration>
@@ -316,7 +317,7 @@
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
                             <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.9.4</version>
+                            <version>1.10.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -335,4 +336,16 @@
             </properties>
         </profile>
     </profiles>
+    <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>javax.ejb-api</artifactId>
+            <version>3.2</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/javax/interceptor/Interceptors.java
+++ b/src/main/java/javax/interceptor/Interceptors.java
@@ -53,6 +53,8 @@ public @interface Interceptors {
 
     /**
      * An ordered list of interceptors.
+     * 
+     * @return an array representing the interceptor classes
      */
     Class[] value();
 }

--- a/src/main/java/javax/interceptor/InvocationContext.java
+++ b/src/main/java/javax/interceptor/InvocationContext.java
@@ -134,8 +134,6 @@ public interface InvocationContext {
      * @return the context data associated with this invocation or
      * lifecycle callback.  If there is no context data, an
      * empty {@code Map<String,Object>} object will be returned.
-     * 
-     * @return the context data, as a map
      */
     public Map<String, Object> getContextData();
 

--- a/src/main/java/javax/interceptor/package.html
+++ b/src/main/java/javax/interceptor/package.html
@@ -163,7 +163,8 @@ invoked before the target instance and all interceptor instances associated with
 destroyed.</p>
 
 <p>When a {@link javax.interceptor.AroundConstruct} lifecycle callback interceptor 
-is used, the following rules apply:
+is used, the following rules apply:</p>
+
 <ul>
   <li>The {@link javax.interceptor.AroundConstruct} lifecycle callback is invoked 
   after dependency injection has been completed on instances of all interceptor 
@@ -187,7 +188,6 @@ is used, the following rules apply:
   method should exercise caution when invoking methods of the target instance since its 
   dependency injection may not have been completed.</li>
 </ul>
-</p>
 
 <h3>Interceptors for lifecycle callbacks</h3>
 


### PR DESCRIPTION
I had to add EJB and Common Annotations dependencies for JavaDoc to work (I think that's needed since Java 8).