### PR TITLE
Version of spec-version-maven-plugin updated to 2.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>2.0</version>
                 <configuration>
                     <specMode>jakarta</specMode>
                     <spec>


### PR DESCRIPTION
This fixes Bundle-SymbolicName issue.