### PR TITLE
Update the parent pom version to 1.0.6 to use the correct OSSRH settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.interceptor-api</groupId>


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

This allows the CI builds to use the correct jakarta.oss.sonatype.org server settings