### PR TITLE
Fix spec parent

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.interceptor-api</groupId>
         <artifactId>interceptor-api-parent</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>interceptors-spec</artifactId>


### PR DESCRIPTION
Solves:
```
[ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.eclipse.ee4j.interceptor-api:interceptors-spec:1.2.5-SNAPSHOT: Could not find artifact org.eclipse.ee4j.interceptor-api:interceptor-api-parent:pom:1.2.5-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 22, column 13
```

