### PR TITLE
Use parent from reactor

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,10 +21,9 @@
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.5</version>
-        <relativePath/>
+        <groupId>org.eclipse.ee4j.interceptor-api</groupId>
+        <artifactId>interceptor-api-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
    <groupId>jakarta.interceptor</groupId>


### PR DESCRIPTION
Currently change from #54 is only usable in spec, but not in api module.