### PR TITLE
EJB should stand for Enterprise Jakarta Beans

### DIFF
--- a/spec/src/main/asciidoc/1_overview.adoc
+++ b/spec/src/main/asciidoc/1_overview.adoc
@@ -28,7 +28,7 @@ class.
 
 This document is an update to the
 Jakarta Interceptors specification 1.2. Version 1.1 was based on the
-Interceptors chapter of the Enterprise JavaBeansTM 3.0 (EJB)
+Interceptors chapter of the Enterprise JavaBeans(TM) 3.0
 specification [<<bib1>>]. Version
 1.2 included interceptor binding definitions that were originally
 defined in the Contexts and Dependency Injection for the Jakarta EE
@@ -41,7 +41,7 @@ The change log for the current version is found in <<change_log>>.
 
 The Jakarta EE Platform specification requires
 support for interceptors. The use of interceptors defined by means of
-the `Interceptors` annotation is required to be supported for EJB and
+the `Interceptors` annotation is required to be supported for Enterprise Jakarta Beans (EJB) and
 Managed Bean components, including in the absence of CDI. When CDI is
 enabled, the use of interceptors defined both by means of interceptor
 binding annotations and by means of the `Interceptors` annotation is


### PR DESCRIPTION
As far as I understand the abbreviation 'EJB' should stand for Enterprise Jakarta Beans since this release