### PR TITLE
Fix references to Enterprise Jakarta Beans

### DIFF
--- a/spec/src/main/asciidoc/1_overview.adoc
+++ b/spec/src/main/asciidoc/1_overview.adoc
@@ -41,15 +41,15 @@ The change log for the current version is found in <<change_log>>.
 
 The Jakarta EE Platform specification requires
 support for interceptors. The use of interceptors defined by means of
-the `Interceptors` annotation is required to be supported for Enterprise 
-Jakarta Beans and Managed Bean components, including in the absence of CDI.
+the `Interceptors` annotation is required to be supported for Jakarta Enterprise 
+Beans and Managed Bean components, including in the absence of CDI.
 When CDI is enabled, the use of interceptors defined both by means of interceptor
 binding annotations and by means of the `Interceptors` annotation is
 required to be supported for component classes that support injection,
 as described in the section “Annotations and Injection” of the Jakarta EE
 Platform specification [<<bib6>>].
 
-Both the Enterprise Jakarta Beans and the CDI specifications
+Both the Jakarta Enterprise Beans and the CDI specifications
 provide extensions to this specification. Other specifications may
 choose to do so in the future. Such specifications are referred to in
 this document as extension specifications. This document outlines

--- a/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
+++ b/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
@@ -111,7 +111,7 @@ deployment descriptor to specify the invocation order of interceptors or
 to override the order specified in metadata annotations. A deployment
 descriptor can optionally be used to define interceptors, to define
 default interceptors, or to associate interceptors with a target class.
-For example, the Enterprise Jakarta Beans specification [<<bib2>>] requires support for the
+For example, the Jakarta Enterprise Beans specification [<<bib2>>] requires support for the
 `ejb-jar.xml` deployment descriptor and the CDI specification
 [<<bib3>>] requires support for the `beans.xml`
 deployment descriptor.
@@ -538,7 +538,7 @@ _Note: Timeout methods are currently specific
 to Jakarta Enterprise Beans, although Timer Service functionality may be
 extended to other specifications in the future, and extension
 specifications may define events that may be interposed on by
-around-timeout methods. The Timer Service, defined by the Jakarta Enterprise
+around-timeout methods. The enterprise beans Timer Service, defined by the Jakarta Enterprise
 Beans specification [<<bib2>>], is a container-provided service
 that allows the Bean Provider to register enterprise beans for timer
 callbacks according to a calendar-based schedule, at a specified time,

--- a/spec/src/main/asciidoc/5_interceptor_ordering.adoc
+++ b/spec/src/main/asciidoc/5_interceptor_ordering.adoc
@@ -36,7 +36,7 @@ overridden.
 
 An extension specification may define
 alternative mechanisms (e.g., a deployment descriptor such as the CDI
-beans.xml [<<bib3>>] or the Enterprise Jakarta Beans _ejb-jar.xml_
+beans.xml [<<bib3>>] or the Jakarta Enterprise Beans _ejb-jar.xml_
 deployment descriptor [<<bib2>>]) to
 enable and order interceptors, to override the order specified by means
 of annotations, or to disable interceptors.


### PR DESCRIPTION
Change to the correct Jakarta Enterprise Beans

Signed-off-by: arjantijms <arjan.tijms@gmail.com>