### PR TITLE
Remove JAX-RPC reference

### DIFF
--- a/api/src/main/java/jakarta/interceptor/InvocationContext.java
+++ b/api/src/main/java/jakarta/interceptor/InvocationContext.java
@@ -114,9 +114,7 @@ public interface InvocationContext {
 
     /**
      * Enables an interceptor to retrieve or update the data associated with the invocation by another interceptor, business
-     * method, and/or webservices endpoint in the invocation chain. If interceptors are invoked as a result of the
-     * invocation on a web service endpoint, the returned value will be an instance of
-     * <code>jakarta.xml.rpc.handler.MessageContext</code>.
+     * method, and/or webservices endpoint in the invocation chain.
      *
      * @return the context data associated with this invocation or lifecycle callback. If there is no context data, an empty
      * {@code Map<String,Object>} object will be returned.


### PR DESCRIPTION
There is a reference to a non-existing `jakarta.xml.rpc`

Rather than revert it back to `javax.xml.rpc` it is probably better to remove it as an implementation will no longer return that value as JAX-RPC has been removed.