### PR TITLE
Update Jakarta annotations API to newest version.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-B1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There is a new release of jakarta annotations available, see https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/2.1.0-B1/

@arjantijms do you think it would be possible to get an Alpha/Beta release of interceptors with this? CDI is getting Jakarta annotations dependency transitively via interceptors API and we need some of those changes.
Obviously, we can easily workaround this, but it wouldn't be as nice :-)