### PR TITLE
Update for the 2.1 release.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.interceptor</groupId>
     <artifactId>jakarta.interceptor-api</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Jakarta Interceptors</name>
     <description>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>2.1.0-B1</version>
+            <version>2.1.0</version>
         </dependency>
     </dependencies>
 
@@ -176,7 +176,7 @@
                 <version>2.1</version>
                 <configuration>
                     <spec>
-                        <specVersion>2.0</specVersion>
+                        <specVersion>2.1</specVersion>
                         <specImplVersion>${project.version}</specImplVersion>
                         <apiPackage>jakarta.interceptor</apiPackage>
                     </spec>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.eclipse.ee4j.interceptor-api</groupId>
     <artifactId>interceptor-api-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Interceptors Parent</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j.interceptor-api</groupId>
         <artifactId>interceptor-api-parent</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>interceptors-spec</artifactId>

--- a/spec/src/main/asciidoc/1_overview.adoc
+++ b/spec/src/main/asciidoc/1_overview.adoc
@@ -27,8 +27,7 @@ class.
 === Revision History
 
 This document is an update to the
-Jakarta Interceptors specification 1.2. Version 1.1 was based on the
-Interceptors chapter of the Enterprise JavaBeansTM 3.0
+Jakarta Interceptors specification 2.0. Version 2.0 was part of the Jakarta EE 9 [<<bib6>>] javax to jakarta namespace change. Version 1.1 was based on the Interceptors chapter of the Enterprise JavaBeans(TM) 3.0
 specification [<<bib1>>]. Version
 1.2 included interceptor binding definitions that were originally
 defined in the Contexts and Dependency Injection for the Jakarta EE
@@ -47,7 +46,7 @@ When CDI is enabled, the use of interceptors defined both by means of intercepto
 binding annotations and by means of the `Interceptors` annotation is
 required to be supported for component classes that support injection,
 as described in the section “Annotations and Injection” of the Jakarta EE
-Platform specification [<<bib6>>].
+Platform specification [<<bib10>>].
 
 Both the Jakarta Enterprise Beans and the CDI specifications
 provide extensions to this specification. Other specifications may

--- a/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
+++ b/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
@@ -589,7 +589,7 @@ public class MyInterceptor {
     @AroundTimeout
     private Object aroundTimeout(InvocationContext ctx)
             throws Exception {
-        logger.info("processing: " + ctx.getTimer().getInfo());
+        logger.info("processing: " + ctx.getTimer());
         return ctx.proceed();
         ...
     }

--- a/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
+++ b/spec/src/main/asciidoc/2_interceptor_programming_contract.adoc
@@ -113,7 +113,7 @@ descriptor can optionally be used to define interceptors, to define
 default interceptors, or to associate interceptors with a target class.
 For example, the Jakarta Enterprise Beans specification [<<bib2>>] requires support for the
 `ejb-jar.xml` deployment descriptor and the CDI specification
-[<<bib3>>] requires support for the `beans.xml`
+[<<bib3>>,<<bib8>>] requires support for the `beans.xml`
 deployment descriptor.
 
 [[interceptor_life_cycle]]

--- a/spec/src/main/asciidoc/3_associating_interceptors_with_classes_and_methods_using_interceptor_bindings.adoc
+++ b/spec/src/main/asciidoc/3_associating_interceptors_with_classes_and_methods_using_interceptor_bindings.adoc
@@ -14,7 +14,7 @@
 Interceptor bindings are intermediate
 annotations that may be used to associate interceptors with any
 component that is not itself an interceptor or decorator
-see [<<bib6>>].
+see [<<bib10>>].
 
 [[interceptor_binding_types]]
 === Interceptor Binding Types
@@ -146,12 +146,12 @@ applied at method level or constructor level. Note that the interceptor
 bindings applied to the target class may include those inherited from
 its superclasses. The CDI specification rules for the inheritance of
 type-level metadata apply to the inheritance of interceptor bindings
-from superclasses of the target class. See [<<bib3>>].
+from superclasses of the target class. See [<<bib8>>].
 
 An interceptor binding declared on a method
 or constructor replaces an interceptor binding of the same type declared
 at class level or inherited from a superclass footnote:[This requirement
-follows the rules from the Jakarta Annotations specification, section 2.1 &#91;<<bib5>>&#91;.].
+follows the rules from the Jakarta Annotations specification, section 3.1 &#91;<<bib9>>&#91;.].
 
 An extension specification may define
 additional rules for combining interceptor bindings, such as
@@ -201,7 +201,7 @@ interceptor bindings of the interceptor. A method or constructor has an
 interceptor binding of an interceptor if it has an interceptor binding
 with (a) the same type and (b) the same annotation member value for each
 member. An extension specification may further refine this rule. For
-example, the CDI specification [<<bib3>>] adds the
+example, the CDI specification [<<bib8>>,<<bib3>>] adds the
 `jakarta.enterprise.util.Nonbinding` annotation, causing member values to be
 ignored by the resolution process.
 
@@ -318,14 +318,14 @@ the `equals` method.
 Array-valued or annotation-valued members of
 an interceptor binding type are not supported. An extension
 specification may add support for these member types. For example the
-CDI specification [<<bib3>>] adds the
+CDI specification [<<bib3>>,<<bib8>>] adds the
 `jakarta.enterprise.util.Nonbinding` annotation, allowing array-valued or
 annotation-valued members to be used on the annotation type, but ignored
 by the resolution process.
 
 If the set of interceptor bindings of a
 component class or interceptor, including bindings inherited from CDI
-stereotypes [<<bib3>>] and other interceptor bindings,
+stereotypes [<<bib3>>,<<bib8>>] and other interceptor bindings,
 has two instances of a certain interceptor binding type and the
 instances have different values of some annotation member, the container
 automatically detects the problem, treats it as a definition error, and

--- a/spec/src/main/asciidoc/5_interceptor_ordering.adoc
+++ b/spec/src/main/asciidoc/5_interceptor_ordering.adoc
@@ -36,7 +36,7 @@ overridden.
 
 An extension specification may define
 alternative mechanisms (e.g., a deployment descriptor such as the CDI
-beans.xml [<<bib3>>] or the Jakarta Enterprise Beans _ejb-jar.xml_
+beans.xml [<<bib3>>,<<bib8>>] or the Jakarta Enterprise Beans _ejb-jar.xml_
 deployment descriptor [<<bib2>>]) to
 enable and order interceptors, to override the order specified by means
 of annotations, or to disable interceptors.

--- a/spec/src/main/asciidoc/a_bibliography.adoc
+++ b/spec/src/main/asciidoc/a_bibliography.adoc
@@ -22,6 +22,12 @@
 
 - [[bib5,5]] Jakarta™ Annotations version 2.0 . https://jakarta.ee/specifications/annotations/2.0/.
 
-- [[bib6,6]] Jakarta™ EE Platform 9 . https://jakarta.ee/specifications/platform/9/ .
+- [[bib6,6]] Jakarta™ EE Platform 9 . https://jakarta.ee/specifications/platform/9/.
 
 - [[bib7,7]] Jakarta™ Transaction version 2.0 . https://jakarta.ee/specifications/transactions/2.0/ .
+
+- [[bib8,8]] Jakarta™ Contexts and Dependency Injection (CDI specification) version 4.0 . https://jakarta.ee/specifications/cdi/4.0/ .
+
+- [[bib9,9]] Jakarta™ Annotations version 2.1 . https://jakarta.ee/specifications/annotations/2.1/.
+
+- [[bib10,10]] Jakarta™ EE Platform 10 . https://jakarta.ee/specifications/platform/10/ .

--- a/spec/src/main/asciidoc/b_change_log.adoc
+++ b/spec/src/main/asciidoc/b_change_log.adoc
@@ -12,6 +12,12 @@
 [[change_log]]
 == Change Log
 
+=== Changes for 2.1
+Updated dependencies for Jakarta EE 10.
+
+Added JPMS module-info.
+
+=== Changes for 2.0
 Clarified <<relationship_to_other_specifications>> to be consistent with the Jakarta EE Platform specification
 with regard to when interceptors defined by means of the _Interceptors_
 annotation and interceptors defined by means of interceptor bindings are


### PR DESCRIPTION
Signed-off-by: Eclipse CDI Bot <cdi-bot@eclipse.org>
Signed-off-by: Scott M Stark <starksm64@gmail.com>

Updates the annotations version to 2.1.0 as per the 2.1 release plan.
https://projects.eclipse.org/projects/ee4j.interceptors/releases/2.1

Update the references to other specifications and history to align with the current EE10 specifications.